### PR TITLE
set up dokka v2 and github pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,30 @@
+name: Publish Documentation to GitHub Pages
+
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    publish-pages:
+        runs-on: ubuntu-latest
+        permissions:
+            pages: write
+            id-token: write
+        environment:
+            name: github-pages
+            url: ${{ steps.deploy-pages.outputs.page_url }}
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-java@v5
+              with:
+                  distribution: temurin
+                  java-version: 21
+            - run: |
+                  ./gradlew dokkaGenerate
+            - uses: actions/upload-pages-artifact@v4
+              with:
+                  path: build/dokka/html
+            - uses: actions/deploy-pages@v4
+              id: deploy-pages

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("multiplatform") version "2.1.0"
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.dokka") version "1.9.10"
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 repositories {
@@ -78,9 +78,21 @@ kotlin {
     }
 }
 
+dokka {
+    moduleName.set("OSM Opening Hours")
+    dokkaSourceSets {
+        configureEach {
+            sourceLink {
+                remoteUrl("https://github.com/westnordost/osm-opening-hours/tree/v${project.version}/")
+                localDirectory = rootDir
+            }
+        }
+    }
+}
+
 val javadocJar = tasks.register<Jar>("javadocJar") {
     archiveClassifier.set("javadoc")
-    from(tasks.dokkaHtml)
+    from(tasks.dokkaGeneratePublicationHtml.map { it.outputDirectory })
 }
 
 publishing {


### PR DESCRIPTION
Publishing a documentation site will allow other documentation sites (specifically, my gbfs one) to link to it, like how [this one](https://code.sargunv.dev/kotlin-dsv/api/kotlin-dsv/dev.sargunv.kotlindsv/-dsv-format/index.html) links to kotlinx-io and kotlinx-serialization.

Since this repo doesn't have automatic releases set up, I configured the github pages publish action to be triggered manually.

It also requires setting Source in settings to Github Actions:

<img width="3248" height="2120" alt="CleanShot 2025-10-26 at 21 34 41@2x" src="https://github.com/user-attachments/assets/df21fa03-9ce8-4e82-993f-c6df084d8efa" />
