### PR TITLE
Add links to Maven and the API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Maven Central](https://img.shields.io/maven-central/v/de.westnordost/osm-opening-hours?label=Maven)](https://central.sonatype.com/artifact/de.westnordost/osm-opening-hours)
+[![API Reference](https://img.shields.io/badge/API_Reference-blue?logo=Kotlin&logoColor=white)](https://westnordost.github.io/osm-opening-hours/)
+
 # osm-opening-hours
 
 A Kotlin multiplatform library to parse OpenStreetMap opening hours from a string into a data model and back.


### PR DESCRIPTION
As per the comment in #4.

I saw it's linked on the project sidebar, but I _think_ that won't show on klibs.io.

If you don't like badges, can move these links to the text of the readme instead.